### PR TITLE
OpenBSD ifdef

### DIFF
--- a/src/serial.cc
+++ b/src/serial.cc
@@ -1,5 +1,5 @@
 /* Copyright 2012 William Woodall and John Harrison */
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__OpenBSD__)
 # include <alloca.h>
 #endif
 


### PR DESCRIPTION
See diff… alloca.h doesn’t exist on OpenBSD.
