### PR TITLE
fix, by Thomas Hoppe <thomas.hoppe@cesys.com>

### DIFF
--- a/include/serial/impl/unix.h
+++ b/include/serial/impl/unix.h
@@ -47,7 +47,7 @@ namespace serial {
 using std::string;
 using std::invalid_argument;
 
-using serial::SerialExecption;
+using serial::SerialException;
 using serial::IOException;
 
 class serial::Serial::SerialImpl {

--- a/include/serial/impl/win.h
+++ b/include/serial/impl/win.h
@@ -46,7 +46,7 @@ namespace serial {
 using std::string;
 using std::invalid_argument;
 
-using serial::SerialExecption;
+using serial::SerialException;
 using serial::IOException;
 
 class serial::Serial::SerialImpl {

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -194,7 +194,7 @@ public:
    * \see Serial::Serial
    *
    * \throw std::invalid_argument
-   * \throw serial::SerialExecption
+   * \throw serial::SerialException
    * \throw serial::IOException
    */
   void
@@ -619,23 +619,24 @@ private:
 
 };
 
-class SerialExecption : public std::exception
+class SerialException : public std::exception
 {
   // Disable copy constructors
-  void operator=(const SerialExecption&);
-  const SerialExecption& operator=(SerialExecption);
-  const char* e_what_;
+  void operator=(const SerialException&);
+  const SerialException& operator=(SerialException);
+  std::string e_what_;
 public:
-  SerialExecption (const char *description) : e_what_ (description) {}
-  SerialExecption (const SerialExecption& other) {
+  SerialException (const char *description) {
+      std::stringstream ss;
+      ss << "SerialException " << description << " failed.";
+      e_what_ = ss.str();
+  }
+  SerialException (const SerialException& other) {
     e_what_ = other.e_what_;
   }
-
-  virtual const char* what () const throw ()
-  {
-    std::stringstream ss;
-    ss << "SerialException " << e_what_ << " failed.";
-    return ss.str ().c_str ();
+  virtual ~SerialException() throw() {}
+  virtual const char* what () const throw () {
+    return e_what_.c_str();
   }
 };
 
@@ -646,13 +647,23 @@ class IOException : public std::exception
   const IOException& operator=(IOException);
   std::string file_;
   int line_;
-  const char* e_what_;
+  std::string e_what_;
   int errno_;
 public:
   explicit IOException (std::string file, int line, int errnum)
-  : file_(file), line_(line), e_what_ (strerror (errnum)), errno_(errnum) {}
+    : file_(file), line_(line), errno_(errnum) {
+      std::stringstream ss;
+      ss << "IO Exception (" << errno_ << "): " << strerror (errnum);
+      ss << ", file " << file_ << ", line " << line_ << ".";
+      e_what_ = ss.str();
+  }
   explicit IOException (std::string file, int line, const char * description)
-  : file_(file), line_(line), e_what_ (description), errno_(0) {}
+    : file_(file), line_(line), errno_(0) {
+      std::stringstream ss;
+      ss << "IO Exception: " << description;
+      ss << ", file " << file_ << ", line " << line_ << ".";
+      e_what_ = ss.str();
+  }
   virtual ~IOException() throw() {}
   IOException (const IOException& other) {
     e_what_ = other.e_what_;
@@ -660,15 +671,8 @@ public:
 
   int getErrorNumber () { return errno_; }
 
-  virtual const char* what () const throw ()
-  {
-    std::stringstream ss;
-    if (errno_ == 0)
-      ss << "IO Exception: " << e_what_;
-    else
-      ss << "IO Exception (" << errno_ << "): " << e_what_;
-    ss << ", file " << file_ << ", line " << line_ << ".";
-    return ss.str ().c_str ();
+  virtual const char* what () const throw () {
+    return e_what_.c_str();
   }
 };
 
@@ -677,18 +681,19 @@ class PortNotOpenedException : public std::exception
   // Disable copy constructors
   void operator=(const PortNotOpenedException&);
   const PortNotOpenedException& operator=(PortNotOpenedException);
-  const char * e_what_;
+  std::string e_what_;
 public:
-  PortNotOpenedException (const char * description) : e_what_ (description) {}
+  PortNotOpenedException (const char * description)  {
+      std::stringstream ss;
+      ss << "PortNotOpenedException " << description << " failed.";
+      e_what_ = ss.str();
+  }
   PortNotOpenedException (const PortNotOpenedException& other) {
     e_what_ = other.e_what_;
   }
-
-  virtual const char* what () const throw ()
-  {
-    std::stringstream ss;
-    ss << e_what_ << " called before port was opened.";
-    return ss.str ().c_str ();
+  virtual ~PortNotOpenedException() throw() {}
+  virtual const char* what () const throw () {
+    return e_what_.c_str();
   }
 };
 

--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -40,7 +40,7 @@ using std::string;
 using std::stringstream;
 using std::invalid_argument;
 using serial::Serial;
-using serial::SerialExecption;
+using serial::SerialException;
 using serial::PortNotOpenedException;
 using serial::IOException;
 
@@ -73,7 +73,7 @@ Serial::SerialImpl::open ()
     throw invalid_argument ("Empty port is invalid.");
   }
   if (is_open_ == true) {
-    throw SerialExecption ("Serial port already open.");
+    throw SerialException ("Serial port already open.");
   }
 
   fd_ = ::open (port_.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
@@ -495,7 +495,7 @@ Serial::SerialImpl::read (uint8_t *buf, size_t size)
           // Disconnected devices, at least on Linux, show the
           // behavior that they are always ready to read immediately
           // but reading returns nothing.
-          throw SerialExecption ("device reports readiness to read but "
+          throw SerialException ("device reports readiness to read but "
                                  "returned no data (device disconnected?)");
         }
         // Update bytes_read
@@ -510,7 +510,7 @@ Serial::SerialImpl::read (uint8_t *buf, size_t size)
         }
         // If bytes_read > size then we have over read, which shouldn't happen
         if (bytes_read > size) {
-          throw SerialExecption ("read over read, too many bytes where "
+          throw SerialException ("read over read, too many bytes where "
                                  "read, this shouldn't happen, might be "
                                  "a logical error!");
         }
@@ -595,7 +595,7 @@ Serial::SerialImpl::write (const uint8_t *data, size_t length)
           // Disconnected devices, at least on Linux, show the
           // behavior that they are always ready to write immediately
           // but writing returns nothing.
-          throw SerialExecption ("device reports readiness to write but "
+          throw SerialException ("device reports readiness to write but "
                                  "returned no data (device disconnected?)");
         }
         // Update bytes_written
@@ -610,7 +610,7 @@ Serial::SerialImpl::write (const uint8_t *data, size_t length)
         }
         // If bytes_written > size then we have over written, which shouldn't happen
         if (bytes_written > length) {
-          throw SerialExecption ("write over wrote, too many bytes where "
+          throw SerialException ("write over wrote, too many bytes where "
                                  "written, this shouldn't happen, might be "
                                  "a logical error!");
         }
@@ -810,7 +810,7 @@ Serial::SerialImpl::waitForChange ()
     stringstream ss;
     ss << "waitForDSR failed on a call to ioctl(TIOCMIWAIT): "
        << errno << " " << strerror(errno);
-    throw(SerialExecption(ss.str().c_str()));
+    throw(SerialException(ss.str().c_str()));
   }
   return true;
 #endif

--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -11,7 +11,7 @@ using serial::bytesize_t;
 using serial::parity_t;
 using serial::stopbits_t;
 using serial::flowcontrol_t;
-using serial::SerialExecption;
+using serial::SerialException;
 using serial::PortNotOpenedException;
 using serial::IOException;
 
@@ -44,7 +44,7 @@ Serial::SerialImpl::open ()
     throw invalid_argument ("Empty port is invalid.");
   }
   if (is_open_ == true) {
-    throw SerialExecption ("Serial port already open.");
+    throw SerialException ("Serial port already open.");
   }
 
   fd_ = CreateFile(port_.c_str(),

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -19,7 +19,7 @@ using std::size_t;
 using std::string;
 
 using serial::Serial;
-using serial::SerialExecption;
+using serial::SerialException;
 using serial::IOException;
 using serial::bytesize_t;
 using serial::parity_t;


### PR DESCRIPTION
For SerialException's:
- The name was misspelled…
- Use std::string's for error messages to prevent corruption of messages on some platforms
