### PR TITLE
Setting timeout throws an exception on Windows

### DIFF
--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -240,6 +240,17 @@ Serial::SerialImpl::reconfigurePort ()
   if(!SetCommState(fd_, &dcbSerialParams)){
     THROW (IOException, "Error setting serial port settings.");
   }
+
+  // Setup timeouts
+  COMMTIMEOUTS timeouts = {0};
+  timeouts.ReadIntervalTimeout = timeout_.inter_byte_timeout;
+  timeouts.ReadTotalTimeoutConstant = timeout_.read_timeout_constant;
+  timeouts.ReadTotalTimeoutMultiplier = timeout_.read_timeout_multiplier;
+  timeouts.WriteTotalTimeoutConstant = timeout_.write_timeout_constant;
+  timeouts.WriteTotalTimeoutMultiplier = timeout_.write_timeout_multiplier;
+  if (!SetCommTimeouts(fd_, &timeouts)) {
+    THROW (IOException, "Error setting timeouts.");
+  }
 }
 
 void
@@ -312,14 +323,8 @@ void
 Serial::SerialImpl::setTimeout (serial::Timeout &timeout)
 {
   timeout_ = timeout;
-  COMMTIMEOUTS timeouts = {0};
-  timeouts.ReadIntervalTimeout = timeout_.inter_byte_timeout;
-  timeouts.ReadTotalTimeoutConstant = timeout_.read_timeout_constant;
-  timeouts.ReadTotalTimeoutMultiplier = timeout_.read_timeout_multiplier;
-  timeouts.WriteTotalTimeoutConstant = timeout_.write_timeout_constant;
-  timeouts.WriteTotalTimeoutMultiplier = timeout_.write_timeout_multiplier;
-  if(!SetCommTimeouts(fd_, &timeouts)){
-    THROW (IOException, "Error setting timeouts.");
+  if (is_open_) {
+    reconfigurePort ();
   }
 }
 


### PR DESCRIPTION
My Serial object is part of another class, and as such I don't call the constructor with any argument.

On Linux this works fine, but on Windows an exception is thrown when calling "pimpl_->setTimeout(timeout);" in serial/src/serial.cc at line 68. The exception is thrown from serial/src/impl/win.cc at line 335.

I can temporarily skip the call to setTimeout() by commenting out line 68 in serial.cc.

In my own class constructor I setup the serial object "sr" with:

```
sr.setPort(port);
sr.setBaudrate(9600);
sr.setBytesize(serial::eightbits);
sr.setParity(serial::parity_none);
sr.setStopbits(serial::stopbits_one);
```

But if I set a timeout, for example with

```
serial::Timeout to = serial::Timeout::simpleTimeout(1000);
sr.setTimeout(to);
```

I still get an exception thrown on Windows, while on Linux it's fine.
