### PR TITLE
Fix aliasing of stopbits_one_point_five

### DIFF
--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -74,8 +74,8 @@ typedef enum {
  */
 typedef enum {
   stopbits_one = 1,
-  stopbits_one_point_five,
-  stopbits_two = 2
+  stopbits_two = 2,
+  stopbits_one_point_five
 } stopbits_t;
 
 /*!


### PR DESCRIPTION
see: http://stackoverflow.com/questions/11412516/enum-why-can-two-different-element-have-the-same-interger-value

I don't believe this is intentional—I ran into it when a switch statement wouldn't compile due to duplicate cases.

I see that in impl/unix, 1.5 and 2 are the same, whereas in impl/win, there's explicit support for 1.5—except that because of how this enum is/was set up, it would never actually see the stopbits_two codepath.

Some quick research suggests that 1.5 stopbits was historically used with _5 bit data_, and POSIX has never supported it. Given this legacy, maybe it should just be removed altogether? If so, let me know and I'll update the PR.
