### PR TITLE
support for mingw (mxe.cc)

### DIFF
--- a/examples/serial_example.cc
+++ b/examples/serial_example.cc
@@ -55,7 +55,7 @@ int run(int argc, char **argv)
 
   // Argument 2 is the baudrate
   unsigned long baud = 0;
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
   sscanf_s(argv[2], "%lu", &baud);
 #else
   sscanf(argv[2], "%lu", &baud);

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -650,7 +650,7 @@ public:
   explicit IOException (std::string file, int line, int errnum)
     : file_(file), line_(line), errno_(errnum) {
       std::stringstream ss;
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
       char error_str [1024];
       strerror_s(error_str, 1024, errnum);
 #else

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -3,6 +3,10 @@
 # include <alloca.h>
 #endif
 
+#if defined (__MINGW32__)
+# define alloca __builtin_alloca
+#endif
+
 #include "serial/serial.h"
 
 #ifdef _WIN32


### PR DESCRIPTION
I tested these changes with the latest mxe (https://github.com/mxe/mxe) and ros-hydro-catkin.
To workaround catkin issues with cross-compilation I had to copy `devel/*sh` files from directory with native build to directory with cross-compiled build and re-run cmake.
