### PR TITLE
Added return value control in Serial::SerialImpl::close () in unix.cc and win.cc

### DIFF
--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -437,8 +437,14 @@ Serial::SerialImpl::close ()
 {
   if (is_open_ == true) {
     if (fd_ != -1) {
-      ::close (fd_); // Ignoring the outcome
-      fd_ = -1;
+      int retVal;
+      retVal=::close (fd_); 
+        if (retVal==0)
+          fd_ = -1;
+        else
+          {
+          THROW (IOException, errno);
+          }
     }
     is_open_ = false;
   }

--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -260,7 +260,15 @@ Serial::SerialImpl::close ()
 {
   if (is_open_ == true) {
     if (fd_ != INVALID_HANDLE_VALUE) {
-      CloseHandle(fd_);
+      int retVal;
+      retVal=CloseHandle(fd_);
+      if (retVal==0)
+      {
+        stringstream ss;
+        ss << "Error while closing serial port: " << GetLastError();
+        THROW (IOException, ss.str().c_str());    
+      }
+      else
       fd_ = INVALID_HANDLE_VALUE;
     }
     is_open_ = false;


### PR DESCRIPTION
This Pull Request fixes issue #60.

Added return value control in Serial::SerialImpl::close () in unix.cc
If close() returns 0 (success) fd_ is set to -1, else if the return value is -1 (error) an exception is thrown.

Added return value control in Serial::SerialImpl::close () in win.cc
If CloseHandle() returns 0 (error) an exception is thrown, else (success) fd_ = INVALID_HANDLE_VALUE.
