### PR TITLE
fix usage of scoped locks

### DIFF
--- a/src/serial.cc
+++ b/src/serial.cc
@@ -123,14 +123,14 @@ Serial::read_ (uint8_t *buffer, size_t size)
 size_t
 Serial::read (uint8_t *buffer, size_t size)
 {
-  ScopedReadLock (this->pimpl_);
+  ScopedReadLock lock(this->pimpl_);
   return this->pimpl_->read (buffer, size);
 }
 
 size_t
 Serial::read (std::vector<uint8_t> &buffer, size_t size)
 {
-  ScopedReadLock (this->pimpl_);
+  ScopedReadLock lock(this->pimpl_);
   uint8_t *buffer_ = new uint8_t[size];
   size_t bytes_read = this->pimpl_->read (buffer_, size);
   buffer.insert (buffer.end (), buffer_, buffer_+bytes_read);
@@ -141,7 +141,7 @@ Serial::read (std::vector<uint8_t> &buffer, size_t size)
 size_t
 Serial::read (std::string &buffer, size_t size)
 {
-  ScopedReadLock (this->pimpl_);
+  ScopedReadLock lock(this->pimpl_);
   uint8_t *buffer_ = new uint8_t[size];
   size_t bytes_read = this->pimpl_->read (buffer_, size);
   buffer.append (reinterpret_cast<const char*>(buffer_), bytes_read);
@@ -160,7 +160,7 @@ Serial::read (size_t size)
 size_t
 Serial::readline (string &buffer, size_t size, string eol)
 {
-  ScopedReadLock (this->pimpl_);
+  ScopedReadLock lock(this->pimpl_);
   size_t eol_len = eol.length ();
   uint8_t *buffer_ = static_cast<uint8_t*>
                               (alloca (size * sizeof (uint8_t)));
@@ -195,7 +195,7 @@ Serial::readline (size_t size, string eol)
 vector<string>
 Serial::readlines (size_t size, string eol)
 {
-  ScopedReadLock (this->pimpl_);
+  ScopedReadLock lock(this->pimpl_);
   std::vector<std::string> lines;
   size_t eol_len = eol.length ();
   uint8_t *buffer_ = static_cast<uint8_t*>
@@ -236,7 +236,7 @@ Serial::readlines (size_t size, string eol)
 size_t
 Serial::write (const string &data)
 {
-  ScopedWriteLock(this->pimpl_);
+  ScopedWriteLock lock(this->pimpl_);
   return this->write_ (reinterpret_cast<const uint8_t*>(data.c_str()),
                        data.length());
 }
@@ -244,14 +244,14 @@ Serial::write (const string &data)
 size_t
 Serial::write (const std::vector<uint8_t> &data)
 {
-  ScopedWriteLock(this->pimpl_);
+  ScopedWriteLock lock(this->pimpl_);
   return this->write_ (&data[0], data.size());
 }
 
 size_t
 Serial::write (const uint8_t *data, size_t size)
 {
-  ScopedWriteLock(this->pimpl_);
+  ScopedWriteLock lock(this->pimpl_);
   return this->write_(data, size);
 }
 
@@ -264,8 +264,8 @@ Serial::write_ (const uint8_t *data, size_t length)
 void
 Serial::setPort (const string &port)
 {
-  ScopedReadLock(this->pimpl_);
-  ScopedWriteLock(this->pimpl_);
+  ScopedReadLock rlock(this->pimpl_);
+  ScopedWriteLock wlock(this->pimpl_);
   bool was_open = pimpl_->isOpen ();
   if (was_open) close();
   pimpl_->setPort (port);
@@ -351,21 +351,21 @@ Serial::getFlowcontrol () const
 
 void Serial::flush ()
 {
-  ScopedReadLock(this->pimpl_);
-  ScopedWriteLock(this->pimpl_);
+  ScopedReadLock rlock(this->pimpl_);
+  ScopedWriteLock wlock(this->pimpl_);
   pimpl_->flush ();
   read_cache_.clear ();
 }
 
 void Serial::flushInput ()
 {
-  ScopedReadLock(this->pimpl_);
+  ScopedReadLock lock(this->pimpl_);
   pimpl_->flushInput ();
 }
 
 void Serial::flushOutput ()
 {
-  ScopedWriteLock(this->pimpl_);
+  ScopedWriteLock lock(this->pimpl_);
   pimpl_->flushOutput ();
   read_cache_.clear ();
 }


### PR DESCRIPTION
Previously they were getting destroyed immediately because they were not stored in a temporary scope variable.

This was reported by someone else, but I'll leave them anonymous for now and let them identify themselves if they like.
