### PR TITLE
Revert c++11 feature for better backward compatibility.

### DIFF
--- a/src/impl/list_ports/list_ports_win.cc
+++ b/src/impl/list_ports/list_ports_win.cc
@@ -24,7 +24,7 @@ static const DWORD hardware_id_max_length = 256;
 vector<PortInfo>
 serial::list_ports()
 {
-	decltype( serial::list_ports() ) devices_found;
+	vector<PortInfo> devices_found;
 
 	HDEVINFO device_info_set = SetupDiGetClassDevs(
 		(const GUID *) &GUID_DEVCLASS_PORTS,


### PR DESCRIPTION
This c++11 feature was giving us problems on older builds.  Changing this fixes it.
