### PR TITLE
Fixes to allow cross correct encoding on both codeblocks / mingw and VS

### DIFF
--- a/src/impl/list_ports/list_ports_win.cc
+++ b/src/impl/list_ports/list_ports_win.cc
@@ -133,7 +133,7 @@ serial::list_ports()
 			std::string portName = port_name;
 			std::string friendlyName = friendly_name;
 			std::string hardwareId = hardware_id;
-		#endif // !UNICODE
+		#endif
 
 		PortInfo port_entry;
 		port_entry.port = portName;


### PR DESCRIPTION
All of this multi-byte encoding stuff is a bit complex -- it depends on how you compile your code.

I found that the original solution worked in codeblocks / ming32, but didn't work in a visual studio project that was set to use Unicode (rather than multi-byte).

Various stackoverflow sources recommend not using the `TCHAR` and just assuming `wchar_t` but for a library like this it seems to be a flexible way to go.

Currently the assumption is that the `PortInfo` data structure will always contain utf8 encoded strings.
