### PR TITLE
Add include for OSX version checking macros.

### DIFF
--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -27,6 +27,7 @@
 #include <sys/time.h>
 #include <time.h>
 #ifdef __MACH__
+#include <AvailabilityMacros.h>
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif


### PR DESCRIPTION
Make sure AvailabilityMacros.h is included for build systems that do not include it by default.
- Required for macros such as `MAC_OS_X_VERSION_10_3`, `MAC_OS_X_VERSION_MIN_REQUIRED`, etc.
