### PR TITLE
support for mxe (http://mxe.cc)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,10 @@ elseif(UNIX)
     # If unix
     list(APPEND serial_SRCS src/impl/unix.cc)
     list(APPEND serial_SRCS src/impl/list_ports/list_ports_linux.cc)
-elseif()
+else()
     # If windows
     list(APPEND serial_SRCS src/impl/win.cc)
+    list(APPEND serial_SRCS src/impl/list_ports/list_ports_win.cc)
 endif()
 
 ## Add serial library
@@ -49,6 +50,8 @@ if(APPLE)
 	target_link_libraries(${PROJECT_NAME} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY})
 elseif(UNIX)
 	target_link_libraries(${PROJECT_NAME} rt pthread)
+else()
+	target_link_libraries(${PROJECT_NAME} setupapi)
 endif()
 
 ## Uncomment for example

--- a/src/impl/list_ports/list_ports_win.cc
+++ b/src/impl/list_ports/list_ports_win.cc
@@ -10,7 +10,7 @@
 #include "serial/serial.h"
 #include <tchar.h>
 #include <windows.h>
-#include <SetupAPI.h>
+#include <setupapi.h>
 #include <devguid.h>
 #include <cstring>
 


### PR DESCRIPTION
 I have to lower-case `SetupAPI.h` in `list_ports_win.cc`  It should still build fine on Windows platform, but I'm not able to verify that. I have also updated `CMakeLists.txt`to address issue with missing implementation source files and to reflect recently added dependency to setupapi library.
