### PR TITLE
Add MARK/SPACE parity bit option

### DIFF
--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -66,7 +66,9 @@ typedef enum {
 typedef enum {
   parity_none = 0,
   parity_odd = 1,
-  parity_even = 2
+  parity_even = 2,
+  parity_mark = 3,
+  parity_space = 4
 } parity_t;
 
 /*!

--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -369,6 +369,11 @@ Serial::SerialImpl::reconfigurePort ()
     options.c_cflag |=  (PARENB);
   } else if (parity_ == parity_odd) {
     options.c_cflag |=  (PARENB | PARODD);
+  } else if (parity_ == parity_mark) {
+    options.c_cflag |=  (PARENB | CMSPAR | PARODD);
+  } else if (parity_ == parity_space) {
+    options.c_cflag |=  (PARENB | CMSPAR);
+    options.c_cflag &= (tcflag_t) ~(PARODD);
   } else {
     throw invalid_argument ("invalid parity");
   }

--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -216,6 +216,10 @@ Serial::SerialImpl::reconfigurePort ()
     dcbSerialParams.Parity = EVENPARITY;
   } else if (parity_ == parity_odd) {
     dcbSerialParams.Parity = ODDPARITY;
+  } else if (parity_ == parity_mark) {
+    dcbSerialParams.Parity = MARKPARITY;
+  } else if (parity_ == parity_space) {
+    dcbSerialParams.Parity = SPACEPARITY;
   } else {
     throw invalid_argument ("invalid parity");
   }


### PR DESCRIPTION
Add MARK and SPACE parity bit options for windows and linux. 

From [wikipedia](http://en.wikipedia.org/wiki/Parity_bit) the description of those bits
"If the parity bit is present but not used, it may be referred to as mark parity (when the parity bit is always 1) or space parity (the bit is always 0)."
