### PR TITLE
Add 576000 baud support for Unix

### DIFF
--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -269,6 +269,9 @@ Serial::SerialImpl::reconfigurePort ()
 #ifdef B460800
   case 460800: baud = B460800; break;
 #endif
+#ifdef B576000
+  case 576000: baud = B576000; break;
+#endif
 #ifdef B921600
   case 921600: baud = B921600; break;
 #endif


### PR DESCRIPTION
576000 baud is another relatively common baudrate. B576000 is defined in libc6 2.19 on my current system. Not sure about others.