### PR TITLE
Release io_iterator_t object when finished with it in list_ports_osx.cc.

### DIFF
--- a/src/impl/list_ports/list_ports_osx.cc
+++ b/src/impl/list_ports/list_ports_osx.cc
@@ -278,7 +278,8 @@ serial::list_ports(void)
 
         devices_found.push_back(port_info);
     }
-
+    
+    IOObjectRelase(serial_port_iterator);
     return devices_found;
 }
 


### PR DESCRIPTION
Release io_iterator_t object received from IOServiceGetMatchingServices, when you’re finished with it as proposed in documentation: https://developer.apple.com/library/mac/documentation/DeviceDrivers/Conceptual/AccessingHardware/AH_IOKitLib_API/AH_IOKitLib_API.html
The IOKitLib API->Device Discovery and Notification->Looking Up Devices