### PR TITLE
fix for clang build on macosx

### DIFF
--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -522,7 +522,7 @@ Serial::SerialImpl::waitReadable (uint32_t timeout)
 void
 Serial::SerialImpl::waitByteTimes (size_t count)
 {
-  timespec wait_time = { 0, byte_time_ns_ * count };
+  timespec wait_time = { 0, static_cast<long>(byte_time_ns_ * count)};
   pselect (0, NULL, NULL, NULL, &wait_time, NULL);
 }
 


### PR DESCRIPTION
`static_cast<long>` added because POSIX have the next description:

> The `<time.h>` header shall declare the structure `timespec`, which has at least the following members:
`time_t  tv_sec` Seconds.
`long    tv_nsec` Nanoseconds.

On linux and Mac OS X successfully built.
