### PR TITLE
Proposed solution for issue 101

### DIFF
--- a/include/serial/impl/unix.h
+++ b/include/serial/impl/unix.h
@@ -141,7 +141,7 @@ public:
   getPort () const;
 
   void
-  setTimeout (Timeout &timeout);
+  setTimeout (const Timeout &timeout);
 
   Timeout
   getTimeout () const;

--- a/include/serial/impl/win.h
+++ b/include/serial/impl/win.h
@@ -130,7 +130,7 @@ public:
   getPort () const;
 
   void
-  setTimeout (Timeout &timeout);
+  setTimeout (const Timeout &timeout);
 
   Timeout
   getTimeout () const;

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -179,7 +179,7 @@ public:
    */
   Serial (const std::string &port = "",
           uint32_t baudrate = 9600,
-          Timeout timeout = Timeout(),
+          const Timeout &timeout = Timeout(),
           bytesize_t bytesize = eightbits,
           parity_t parity = parity_none,
           stopbits_t stopbits = stopbits_one,
@@ -456,7 +456,7 @@ public:
    * \see serial::Timeout
    */
   void
-  setTimeout (Timeout &timeout);
+  setTimeout (const Timeout &timeout);
 
   /*! Sets the timeout for reads and writes. */
   void

--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -699,7 +699,7 @@ Serial::SerialImpl::getPort () const
 }
 
 void
-Serial::SerialImpl::setTimeout (serial::Timeout &timeout)
+Serial::SerialImpl::setTimeout (const serial::Timeout &timeout)
 {
   timeout_ = timeout;
 }

--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -370,7 +370,7 @@ Serial::SerialImpl::getPort () const
 }
 
 void
-Serial::SerialImpl::setTimeout (serial::Timeout &timeout)
+Serial::SerialImpl::setTimeout (const serial::Timeout &timeout)
 {
   timeout_ = timeout;
   if (is_open_) {

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -63,7 +63,7 @@ private:
   SerialImpl *pimpl_;
 };
 
-Serial::Serial (const string &port, uint32_t baudrate, serial::Timeout timeout,
+Serial::Serial (const string &port, uint32_t baudrate, const serial::Timeout &timeout,
                 bytesize_t bytesize, parity_t parity, stopbits_t stopbits,
                 flowcontrol_t flowcontrol)
  : pimpl_(new SerialImpl (port, baudrate, bytesize, parity,
@@ -279,7 +279,7 @@ Serial::getPort () const
 }
 
 void
-Serial::setTimeout (serial::Timeout &timeout)
+Serial::setTimeout (const serial::Timeout &timeout)
 {
   pimpl_->setTimeout (timeout);
 }


### PR DESCRIPTION
Update to Serial::setTimeout (and unix/win implementations) to accept timeout by const reference

I do not have this repo building but these changes building right now, but figured the changes were minor and limited enough to do them just by eyeballing them.  I hope that this PR is acceptable.  If not, let me know and I'll see what I can do to make it so.

Thank