### PR TITLE
Use CLOCK_MONOTONIC (Linux)/SYSTEM_CLOCK (OS X) to time select()

### DIFF
--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -85,7 +85,7 @@ MillisecondTimer::timespec_now ()
 # ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
   clock_serv_t cclock;
   mach_timespec_t mts;
-  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+  host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
   clock_get_time(cclock, &mts);
   mach_port_deallocate(mach_task_self(), cclock);
   time.tv_sec = mts.tv_sec;

--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -91,7 +91,7 @@ MillisecondTimer::timespec_now ()
   time.tv_sec = mts.tv_sec;
   time.tv_nsec = mts.tv_nsec;
 # else
-  clock_gettime(CLOCK_REALTIME, &time);
+  clock_gettime(CLOCK_MONOTONIC, &time);
 # endif
   return time;
 }


### PR DESCRIPTION
On Linux systems which are being driven by an external time source (NTP or PTP), it is possible that time appears to slew in reverse under `CLOCK_REALTIME`. Since the timer function is used to time durations of events (calls to `select()`), it is better to use `CLOCK_MONOTONIC`, which isn't subject to slewing.