### PR TITLE
Problem: catkin is a required build dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(serial)
 
-# Find catkin
-find_package(catkin REQUIRED)
+option(USE_CATKIN "Use Catkin for packaging" ON)
 
 if(APPLE)
 	find_library(IOKIT_LIBRARY IOKit)
 	find_library(FOUNDATION_LIBRARY Foundation)
-endif()
-
-if(UNIX AND NOT APPLE)
-    # If Linux, add rt and pthread
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include
-        DEPENDS rt pthread
-    )
-else()
-    # Otherwise normal call
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include
-    )
 endif()
 
 ## Sources
@@ -62,17 +46,47 @@ target_link_libraries(serial_example ${PROJECT_NAME})
 ## Include headers
 include_directories(include)
 
-## Install executable
-install(TARGETS ${PROJECT_NAME}
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-)
+if(USE_CATKIN)
+    # Find catkin
+    find_package(catkin REQUIRED)
 
-## Install headers
-install(FILES include/serial/serial.h include/serial/v8stdint.h
-  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/serial)
+    if(UNIX AND NOT APPLE)
+        # If Linux, add rt and pthread
+        catkin_package(
+            LIBRARIES ${PROJECT_NAME}
+            INCLUDE_DIRS include
+            DEPENDS rt pthread
+        )
+    else()
+        # Otherwise normal call
+        catkin_package(
+            LIBRARIES ${PROJECT_NAME}
+            INCLUDE_DIRS include
+        )
+    endif()
 
-## Tests
-if(CATKIN_ENABLE_TESTING)
-    add_subdirectory(tests)
+    ## Install executable
+    install(TARGETS ${PROJECT_NAME}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    )
+
+    ## Install headers
+    install(FILES include/serial/serial.h include/serial/v8stdint.h
+      DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/serial)
+
+    ## Tests
+    if(CATKIN_ENABLE_TESTING)
+        add_subdirectory(tests)
+    endif()
+else()
+    ## Install executable
+    install(TARGETS ${PROJECT_NAME}
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+    )
+
+    ## Install headers
+    install(FILES include/serial/serial.h include/serial/v8stdint.h
+      DESTINATION include/serial)
 endif()


### PR DESCRIPTION
Solution: make it optional

Background: I'm building control software for a scientific instrument and I wanted to use your serial library. It's compiled inside a Docker using a Fedora base image. I tried to `dnf install catkin` and I couldn't get cmake to find catkin after messing around with ros' environment scripts and such. And catkin is completely irrelevant to what I'm doing, so I just made it an optional build dependency (on by default).