### PR TITLE
Problem: hardware flow control uses RTS_CONTROL_TOGGLE

### DIFF
--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -239,19 +239,19 @@ Serial::SerialImpl::reconfigurePort ()
   // setup flowcontrol
   if (flowcontrol_ == flowcontrol_none) {
     dcbSerialParams.fOutxCtsFlow = false;
-    dcbSerialParams.fRtsControl = 0x00;
+    dcbSerialParams.fRtsControl = RTS_CONTROL_DISABLE;
     dcbSerialParams.fOutX = false;
     dcbSerialParams.fInX = false;
   }
   if (flowcontrol_ == flowcontrol_software) {
     dcbSerialParams.fOutxCtsFlow = false;
-    dcbSerialParams.fRtsControl = 0x00;
+    dcbSerialParams.fRtsControl = RTS_CONTROL_DISABLE;
     dcbSerialParams.fOutX = true;
     dcbSerialParams.fInX = true;
   }
   if (flowcontrol_ == flowcontrol_hardware) {
     dcbSerialParams.fOutxCtsFlow = true;
-    dcbSerialParams.fRtsControl = 0x03;
+    dcbSerialParams.fRtsControl = RTS_CONTROL_HANDSHAKE;
     dcbSerialParams.fOutX = false;
     dcbSerialParams.fInX = false;
   }


### PR DESCRIPTION
RTS_CONTROL_HANDSHAKE raises RTS when there is space in the input
buffer; RTS_CONTROL_TOGGLE only raises RTS when bytes are available for
transmission.

Also replace numeric constants with symbolic constants.

I was trying to communicate with a serial device that requires hardware flow control, and I run into an issue where I was unable to receive messages unless I send a dummy character like `\r`. After a lot of frustration (serial is fiddly ;)) I found that this library uses RTS_CONTROL_TOGGLE and proper hardware flow control should use RTS_CONTROL_HANDSHAKE.
