### PR TITLE
Const correction.

### DIFF
--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -717,7 +717,7 @@ public:
   virtual ~IOException() throw() {}
   IOException (const IOException& other) : line_(other.line_), e_what_(other.e_what_), errno_(other.errno_) {}
 
-  int getErrorNumber () { return errno_; }
+  int getErrorNumber () const { return errno_; }
 
   virtual const char* what () const throw () {
     return e_what_.c_str();


### PR DESCRIPTION
Allows exception number to be accessed in a typical try { } catch() { } block like this:

```cpp
    try
    {
    // init the port
    }
    catch (const serial::IOException& exc)
    {
        if (exc.getErrorNumber() == EBUSY)
        {
            ofLogError("SerialDevice::setup") << portName << " is busy -- is it in use by another application?";
        }
        else
        {
            ofLogError("SerialDevice::setup") << exc.what();
        }

        return false;
    }

```