### PR TITLE
incorrect timeouts "expiry" calculation on Unix systems

### DIFF
--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -62,7 +62,7 @@ MillisecondTimer::MillisecondTimer (const uint32_t millis)
   int64_t tv_nsec = expiry.tv_nsec + (millis * 1e6);
   if (tv_nsec >= 1e9) {
     int64_t sec_diff = tv_nsec / static_cast<int> (1e9);
-    expiry.tv_nsec = tv_nsec - static_cast<int> (1e9 * sec_diff);
+    expiry.tv_nsec %= static_cast<int>(1e9);
     expiry.tv_sec += sec_diff;
   } else {
     expiry.tv_nsec = tv_nsec;


### PR DESCRIPTION
found this cool project today.

I decided to perform some basic tests and assigned 5 seconds timeout to serial_port... But instead of 5 seconds, read() method has blocked for ~13 seconds!

I made some investigations and found that error occurs due to an overflow in "signed long" variable (tv_nsec field of timespec_t) https://github.com/wjwwood/serial/blob/master/src/impl/unix.cc#L65

however, there is no need to subtract sec_diff from tv_nsec. this operation can be easily replaced with division by modulo.

The code to reproduce an error:
````
#include <string>
#include <iostream>
#include "serial/serial.h"

int main(int argc, char **argv) {
    serial::Serial my_serial("/dev/ttyFAKE", 115200, serial::Timeout::simpleTimeout(5000));
    std::string line = my_serial.readline();
    return 0;
}
````
