### PR TITLE
fixing unix timeouts handling ("timer_tests.short_interval" failure)

### DIFF
--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -62,7 +62,7 @@ MillisecondTimer::MillisecondTimer (const uint32_t millis)
   int64_t tv_nsec = expiry.tv_nsec + (millis * 1e6);
   if (tv_nsec >= 1e9) {
     int64_t sec_diff = tv_nsec / static_cast<int> (1e9);
-    expiry.tv_nsec %= static_cast<int>(1e9);
+    expiry.tv_nsec = tv_nsec % static_cast<int>(1e9);
     expiry.tv_sec += sec_diff;
   } else {
     expiry.tv_nsec = tv_nsec;


### PR DESCRIPTION
fixup for 4d69fb2e4139ccd1b6287ae7a98c20d2eca7740e
now "timer_tests.short_interval" should be green.