### PR TITLE
Implement flushInput and flushOutput for windows

### DIFF
--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -471,13 +471,19 @@ Serial::SerialImpl::flush ()
 void
 Serial::SerialImpl::flushInput ()
 {
-  THROW (IOException, "flushInput is not supported on Windows.");
+  if (is_open_ == false) {
+    throw PortNotOpenedException("Serial::flushInput");
+  }
+  PurgeComm(fd_, PURGE_RXCLEAR);
 }
 
 void
 Serial::SerialImpl::flushOutput ()
 {
-  THROW (IOException, "flushOutput is not supported on Windows.");
+  if (is_open_ == false) {
+    throw PortNotOpenedException("Serial::flushOutput");
+  }
+  PurgeComm(fd_, PURGE_TXCLEAR);
 }
 
 void


### PR DESCRIPTION
This relates to issue #148.

This PR implements `flushInput` and `flushOutput` for Windows. The behavior is the same as their Unix counterparts, in that:

-`flushOutput` clears the contents of an output buffer without transmitting the deleted characters (as opposed to `flush`, which clears the contents of the output buffer and transmits the deleted characters).
-`flushInput` clears the contents of the input buffer.

Refer to [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363428(v=vs.85).aspx) for more details.