### PR TITLE
make windows hardware flow control work the same as unix

### DIFF
--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -250,10 +250,11 @@ Serial::SerialImpl::reconfigurePort ()
     dcbSerialParams.fInX = true;
   }
   if (flowcontrol_ == flowcontrol_hardware) {
-    dcbSerialParams.fOutxCtsFlow = true;
-    dcbSerialParams.fRtsControl = 0x03;
-    dcbSerialParams.fOutX = false;
-    dcbSerialParams.fInX = false;
+    dcbSerialParams.fOutxCtsFlow = TRUE;
+    dcbSerialParams.fOutxDsrFlow = FALSE;
+    dcbSerialParams.fRtsControl = RTS_CONTROL_HANDSHAKE;
+    dcbSerialParams.fOutX = FALSE;
+    dcbSerialParams.fInX = FALSE;
   }
 
   // activate settings


### PR DESCRIPTION
Currently, `DCB::fRtsControl` is set to `0x03` [which is for `RTS_CONTROL_TOGGLE`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363214(v=vs.85).aspx) for RTS toggle functionality on Windows. Unix doesn't support RTS toggle, so the library doesn't behave the same on Windows/Unix.

This PR switches the RTS control to `RTS_CONTROL_HANDSHAKE`, which seems to behave the same as the Unix hardware flow control implementation (and is also the more standard way of using serial).