### PR TITLE
Serial port read returns no data with Arduino Leonardo

### DIFF
--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -70,7 +70,7 @@ Serial::SerialImpl::open ()
                     0,
                     0,
                     OPEN_EXISTING,
-                    FILE_ATTRIBUTE_NORMAL,
+					FILE_ATTRIBUTE_NORMAL, // FILE_FLAG_OVERLAPPED
                     0);
 
   if (fd_ == INVALID_HANDLE_VALUE) {
@@ -107,6 +107,20 @@ Serial::SerialImpl::reconfigurePort ()
     //error getting state
     THROW (IOException, "Error getting the serial port state.");
   }
+
+  // Boilerplate default settings
+  dcbSerialParams.fBinary = TRUE;
+  dcbSerialParams.fDtrControl = DTR_CONTROL_ENABLE;
+  dcbSerialParams.fDsrSensitivity = FALSE;
+  dcbSerialParams.fTXContinueOnXoff = FALSE;
+  dcbSerialParams.fOutX = FALSE;
+  dcbSerialParams.fInX = FALSE;
+  dcbSerialParams.fErrorChar = FALSE;
+  dcbSerialParams.fNull = FALSE;
+  dcbSerialParams.fRtsControl = RTS_CONTROL_ENABLE;
+  dcbSerialParams.fAbortOnError = FALSE;
+  dcbSerialParams.fOutxCtsFlow = FALSE;
+  dcbSerialParams.fOutxDsrFlow = FALSE;
 
   // setup baud rate
   switch (baudrate_) {


### PR DESCRIPTION
I ran into a problem with an Arduino Leonardo board.   When first plugged I was able to open the serial port without error, but could not read any data from the device.   I tried explicitly setting each of the serial parameters, but the only thing that was working for me was to run PuTTY before running my own code that uses 'serial', in which case the port would work correctly, only to fail again the next time I plugged in the board.

This patch borrows the boilerplate device control block settings from PuTTY to initialize the serial device, which fixes the problem with 'serial'.