### PR TITLE
Fix CMake warning for rt and pthread.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 
 if(UNIX AND NOT APPLE)
     # If Linux, add rt and pthread
+    set(rt_LIBRARIES rt)
+    set(pthread_LIBRARIES pthread)
     catkin_package(
         LIBRARIES ${PROJECT_NAME}
         INCLUDE_DIRS include


### PR DESCRIPTION
Squelches the following CMake warning when building on Linux:

```
-- ==> add_subdirectory(serial)
CMake Warning at share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'rt' but neither 'rt_INCLUDE_DIRS' nor
  'rt_LIBRARIES' is defined.
Call Stack (most recent call first):
  share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  serial/CMakeLists.txt:14 (catkin_package)

CMake Warning at share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'pthread' but neither 'pthread_INCLUDE_DIRS'
  nor 'pthread_LIBRARIES' is defined.
Call Stack (most recent call first):
  share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  serial/CMakeLists.txt:14 (catkin_package)
```

However, this would also be fixed by merging #133, so it depends a bit on the next steps for that PR.