### PR TITLE
Support 500kbps serial ports.

### DIFF
--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -488,7 +488,7 @@ public:
    * 110, 300, 600, 1200, 2400, 4800, 9600, 14400, 19200, 28800, 38400, 56000,
    * 57600, 115200
    * Some other baudrates that are supported by some comports:
-   * 128000, 153600, 230400, 256000, 460800, 921600
+   * 128000, 153600, 230400, 256000, 460800, 500000, 921600
    *
    * \param baudrate An integer that sets the baud rate for the serial port.
    *

--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -269,6 +269,9 @@ Serial::SerialImpl::reconfigurePort ()
 #ifdef B460800
   case 460800: baud = B460800; break;
 #endif
+#ifdef B500000
+  case 500000: baud = B500000; break;
+#endif
 #ifdef B576000
   case 576000: baud = B576000; break;
 #endif


### PR DESCRIPTION
Some RS422 devices use this baud rate; see similar logic in picocom:

https://github.com/npat-efault/picocom/blob/a6b1dda2aba366af99c10950dce4336373f5854e/term.c#L266-L268

Seems like this [was added in 1.8](https://github.com/npat-efault/picocom/releases/tag/1.8). It would be great to have support in Serial as well.