### PR TITLE
Fix windows com port prefix

### DIFF
--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -24,7 +24,7 @@ inline wstring
 _prefix_port_if_needed(const wstring &input)
 {
   static wstring windows_com_port_prefix = L"\\\\.\\";
-  if (input.compare(windows_com_port_prefix) != 0)
+  if (input.compare(0, windows_com_port_prefix.size(), windows_com_port_prefix) != 0)
   {
     return windows_com_port_prefix + input;
   }


### PR DESCRIPTION
The check in `_prefix_port_if_needed` does not work, as it's currently comparing the whole input string to the prefix. As a consequence, port strings will be prefixed, even if they're already prefixed. This commit changes the call to `wstring::compare` to use an overload that compares a substring of the input string only.