### PR TITLE
Fix memory leak when exception is thrown by impl class.

### DIFF
--- a/src/serial.cc
+++ b/src/serial.cc
@@ -132,7 +132,16 @@ Serial::read (std::vector<uint8_t> &buffer, size_t size)
 {
   ScopedReadLock lock(this->pimpl_);
   uint8_t *buffer_ = new uint8_t[size];
-  size_t bytes_read = this->pimpl_->read (buffer_, size);
+  size_t bytes_read = 0;
+
+  try {
+    bytes_read = this->pimpl_->read (buffer_, size);
+  }
+  catch (const std::exception &e) {
+    delete[] buffer_;
+    throw;
+  }
+
   buffer.insert (buffer.end (), buffer_, buffer_+bytes_read);
   delete[] buffer_;
   return bytes_read;
@@ -143,7 +152,14 @@ Serial::read (std::string &buffer, size_t size)
 {
   ScopedReadLock lock(this->pimpl_);
   uint8_t *buffer_ = new uint8_t[size];
-  size_t bytes_read = this->pimpl_->read (buffer_, size);
+  size_t bytes_read = 0;
+  try {
+    bytes_read = this->pimpl_->read (buffer_, size);
+  }
+  catch (const std::exception &e) {
+    delete[] buffer_;
+    throw;
+  }
   buffer.append (reinterpret_cast<const char*>(buffer_), bytes_read);
   delete[] buffer_;
   return bytes_read;


### PR DESCRIPTION
This fixes a memory leak when exceptions are thrown by the Impl classes in the read function variants of
`Serial::read (std::vector<uint8_t> &buffer, size_t size)` & `Serial::read (std::string &buffer, size_t size)`

An alternate strategy for the fix could have been to use smart pointers but chose the proposed fix so as to be inline with the coding conventions used in the library.
