### PR TITLE
Refine setTimeout by const reference

### DIFF
--- a/include/serial/impl/unix.h
+++ b/include/serial/impl/unix.h
@@ -141,7 +141,7 @@ public:
   getPort () const;
 
   void
-  setTimeout (Timeout &timeout);
+  setTimeout (const Timeout &timeout);
 
   Timeout
   getTimeout () const;

--- a/include/serial/impl/win.h
+++ b/include/serial/impl/win.h
@@ -130,7 +130,7 @@ public:
   getPort () const;
 
   void
-  setTimeout (Timeout &timeout);
+  setTimeout (const Timeout &timeout);
 
   Timeout
   getTimeout () const;

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -458,7 +458,7 @@ public:
    * \see serial::Timeout
    */
   void
-  setTimeout (Timeout &timeout);
+  setTimeout (const Timeout &timeout);
 
   /*! Sets the timeout for reads and writes. */
   void

--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -707,7 +707,7 @@ Serial::SerialImpl::getPort () const
 }
 
 void
-Serial::SerialImpl::setTimeout (serial::Timeout &timeout)
+Serial::SerialImpl::setTimeout (const serial::Timeout &timeout)
 {
   timeout_ = timeout;
 }

--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -370,7 +370,7 @@ Serial::SerialImpl::getPort () const
 }
 
 void
-Serial::SerialImpl::setTimeout (serial::Timeout &timeout)
+Serial::SerialImpl::setTimeout (const serial::Timeout &timeout)
 {
   timeout_ = timeout;
   if (is_open_) {

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -295,7 +295,7 @@ Serial::getPort () const
 }
 
 void
-Serial::setTimeout (serial::Timeout &timeout)
+Serial::setTimeout (const serial::Timeout &timeout)
 {
   pimpl_->setTimeout (timeout);
 }


### PR DESCRIPTION
for support rvalue of timeout, otherwise we will got compile error, eg:
serial_->setTimeout(serial::Timeout::simpleTimeout(1000));