### PR TITLE
Install target generates a clean CMake package (+ Catkin dependency is now optional) 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,35 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(serial)
+## Options 
+# Use Catkin (disabled by default)
+option(USE_CATKIN off)
 
 # Find catkin
-find_package(catkin REQUIRED)
+if(USE_CATKIN)
+    find_package(catkin REQUIRED)
 
-if(APPLE)
-    find_library(IOKIT_LIBRARY IOKit)
-    find_library(FOUNDATION_LIBRARY Foundation)
-endif()
-
-if(UNIX AND NOT APPLE)
+    if(UNIX AND NOT APPLE)
     # If Linux, add rt and pthread
-    set(rt_LIBRARIES rt)
-    set(pthread_LIBRARIES pthread)
     catkin_package(
         LIBRARIES ${PROJECT_NAME}
         INCLUDE_DIRS include
         DEPENDS rt pthread
     )
-else()
-    # Otherwise normal call
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include
-    )
+    else()
+        # Otherwise normal call
+        catkin_package(
+            LIBRARIES ${PROJECT_NAME}
+            INCLUDE_DIRS include
+        )
+    endif()
 endif()
 
+
+
+if(APPLE)
+	find_library(IOKIT_LIBRARY IOKit)
+	find_library(FOUNDATION_LIBRARY Foundation)
+endif()
 ## Sources
 set(serial_SRCS
     src/serial.cc
@@ -64,15 +68,20 @@ target_link_libraries(serial_example ${PROJECT_NAME})
 ## Include headers
 include_directories(include)
 
-## Install executable
-install(TARGETS ${PROJECT_NAME}
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-)
+if(USE_CATKIN)
+    ## Install headers
+    install(FILES include/serial/serial.h include/serial/v8stdint.h
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/serial)
+    ## Install executable
+    install(TARGETS ${PROJECT_NAME}
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    )
 
 ## Install headers
 install(FILES include/serial/serial.h include/serial/v8stdint.h
   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/serial)
+endif()
 
 ## Tests
 if(CATKIN_ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(serial)
 ## Options 
 # Use Catkin (disabled by default)
 option(USE_CATKIN off)
+# Build serial sample 
+option(BUILD_SAMPLE on)
 
 # Find catkin
 if(USE_CATKIN)
@@ -60,10 +62,15 @@ else()
     target_link_libraries(${PROJECT_NAME} setupapi)
 endif()
 
-## Uncomment for example
-add_executable(serial_example examples/serial_example.cc)
-add_dependencies(serial_example ${PROJECT_NAME})
-target_link_libraries(serial_example ${PROJECT_NAME})
+## Include headers
+
+
+## Example
+if(BUILD_SAMPLE)
+    add_executable(serial_example examples/serial_example.cc)
+    add_dependencies(serial_example ${PROJECT_NAME})
+    target_link_libraries(serial_example ${PROJECT_NAME})
+endif()
 
 ## Include headers
 include_directories(include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,19 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(serial)
+
+# Either this or bump cmake_minimum_required to 3.0+
+# Allow us to use Version in project() call : https://cmake.org/cmake/help/v3.0/policy/CMP0048.html#policy:CMP0048
+cmake_policy(SET CMP0048 NEW)
+
+project(serial VERSION 1.2.1)
+
+
 ## Options 
+
 # Use Catkin (disabled by default)
 option(USE_CATKIN off)
 # Build serial sample 
 option(BUILD_SAMPLE on)
+
 
 # Find catkin
 if(USE_CATKIN)
@@ -32,16 +41,20 @@ if(APPLE)
 	find_library(IOKIT_LIBRARY IOKit)
 	find_library(FOUNDATION_LIBRARY Foundation)
 endif()
+
+
+
 ## Sources
 set(serial_SRCS
     src/serial.cc
     include/serial/serial.h
     include/serial/v8stdint.h
 )
+
 if(APPLE)
-    # If OSX
-    list(APPEND serial_SRCS src/impl/unix.cc)
-    list(APPEND serial_SRCS src/impl/list_ports/list_ports_osx.cc)
+	# If OSX
+	list(APPEND serial_SRCS src/impl/unix.cc)
+	list(APPEND serial_SRCS src/impl/list_ports/list_ports_osx.cc)
 elseif(UNIX)
     # If unix
     list(APPEND serial_SRCS src/impl/unix.cc)
@@ -53,16 +66,18 @@ else()
 endif()
 
 ## Add serial library
-add_library(${PROJECT_NAME} ${serial_SRCS})
+add_library(${PROJECT_NAME} STATIC ${serial_SRCS})
+
 if(APPLE)
-    target_link_libraries(${PROJECT_NAME} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY})
+	target_link_libraries(${PROJECT_NAME} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY})
 elseif(UNIX)
-    target_link_libraries(${PROJECT_NAME} rt pthread)
+	target_link_libraries(${PROJECT_NAME} rt pthread)
 else()
-    target_link_libraries(${PROJECT_NAME} setupapi)
+	target_link_libraries(${PROJECT_NAME} setupapi)
 endif()
 
 ## Include headers
+target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>)
 
 
 ## Example
@@ -72,8 +87,16 @@ if(BUILD_SAMPLE)
     target_link_libraries(serial_example ${PROJECT_NAME})
 endif()
 
-## Include headers
-include_directories(include)
+
+## Export 
+
+# Set postfix names for exporting
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    RELEASE_POSTFIX ""
+    RELWITHDEBINFO_POSTFIX "-rd"
+    MINSIZEREL_POSTFIX "-mr"
+    DEBUG_POSTFIX "-d")  
+
 
 if(USE_CATKIN)
     ## Install headers
@@ -84,11 +107,45 @@ if(USE_CATKIN)
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     )
+else()
+    set(EXPORT_TARGET_NAME serialTargets)
 
-## Install headers
-install(FILES include/serial/serial.h include/serial/v8stdint.h
-  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/serial)
+    install(EXPORT ${EXPORT_TARGET_NAME} DESTINATION cmake/)
+    # Include module with fuction 'write_basic_package_version_file' and 'configure_package_config_file'
+    include(CMakePackageConfigHelpers)
+
+    set(OUTPUT_CMAKE_EXPORT_GENERATED_FILES ${CMAKE_BINARY_DIR}/CMakeExportConfig)
+    # Configure '<PROJECT-NAME>ConfigVersion.cmake'
+    write_basic_package_version_file(${OUTPUT_CMAKE_EXPORT_GENERATED_FILES}/${PROJECT_NAME}Config-version.cmake
+        # <AnyNewerVersion|SameMajorVersion|SameMinorVersion|ExactVersion> 
+        # Careful : SameMinorVersion and ExactVersion were introduced in CMake 3.11
+        COMPATIBILITY SameMajorVersion
+    )
+
+    # Configure '<PROJECT-NAME>Config.cmake'
+    configure_package_config_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
+        "${OUTPUT_CMAKE_EXPORT_GENERATED_FILES}/${PROJECT_NAME}Config.cmake"
+        INSTALL_DESTINATION "${CMAKE_INSTALL_PREFIX}/cmake"
+    )
+
+    # Install config file generated
+    install(DIRECTORY ${OUTPUT_CMAKE_EXPORT_GENERATED_FILES}/ 
+        DESTINATION cmake/)
+
+
+    ## Install headers
+    install(FILES include/serial/serial.h include/serial/v8stdint.h
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/include/serial)
+
+   ## Install executable
+    install(TARGETS ${PROJECT_NAME} EXPORT ${EXPORT_TARGET_NAME}
+        INCLUDES DESTINATION $<INSTALL_INTERFACE:include/>
+        ARCHIVE DESTINATION ${__dest} COMPONENT ${TARGET_NAME}
+    )
 endif()
+
+
 
 ## Tests
 if(CATKIN_ENABLE_TESTING)

--- a/cmake/serialConfig.cmake.in
+++ b/cmake/serialConfig.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+
+include("${CMAKE_CURRENT_LIST_DIR}/@EXPORT_TARGET_NAME@.cmake")
+
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Install target now generate a clean CMake package :

- `lib` folder that contains the static library (debug and release)
- `include` folder that contains the *.h
- `cmake` folder that contains all the cmake related files (exported targets + version file)

This allow the package to be found by a `find_package()` call if you set `serial_DIR` var to the path of  `cmake` folder.

```
# You can also specify the version if needed
find_package(serial REQUIRED)

# Don't need to specify serial include directories as the target already defines them.  
target_link_libraries(my_target PUBLIC serial)
``` 

This PR also disable Catkin dependency by default, you can restore it by setting `USE_CATKIN` option to ON. 

Also the option `BUILD_SAMPLE` allow you to build or not the sample (default is ON).

This is somewhat #133 is trying to do while keeping Catkin dependency as an option if needed.
