### PR TITLE
Add support for serial bluetooth ports on Linux

### DIFF
--- a/src/impl/list_ports/list_ports_linux.cc
+++ b/src/impl/list_ports/list_ports_linux.cc
@@ -305,6 +305,7 @@ serial::list_ports()
     search_globs.push_back("/dev/ttyUSB*");
     search_globs.push_back("/dev/tty.*");
     search_globs.push_back("/dev/cu.*");
+    search_globs.push_back("/dev/rfcomm*");
 
     vector<string> devices_found = glob( search_globs );
 


### PR DESCRIPTION
Added search blob /dev/rfcomm*. rfcomm* is a commonly used naming
convention for bluetooth ports on linux