### PR TITLE
MinGW alloca redefined

### DIFF
--- a/src/serial.cc
+++ b/src/serial.cc
@@ -5,7 +5,7 @@
 # include <alloca.h>
 #endif
 
-#if defined (__MINGW32__)
+#if defined (__MINGW32__) && !defined(alloca)
 # define alloca __builtin_alloca
 #endif
 


### PR DESCRIPTION
This fixes the "alloca" being redefined in MinGW 8.1.