### PR TITLE
Build source for unix platforms, instead of just linux

### DIFF
--- a/src/impl/list_ports/list_ports_linux.cc
+++ b/src/impl/list_ports/list_ports_linux.cc
@@ -1,4 +1,4 @@
-#if defined(__linux__)
+#if (defined(__linux__) || defined(__unix__))
 
 /*
  * Copyright (c) 2014 Craig Lilley <cralilley@gmail.com>

--- a/tests/unix_serial_tests.cc
+++ b/tests/unix_serial_tests.cc
@@ -27,7 +27,7 @@ void loop()
 
 #include "serial/serial.h"
 
-#if defined(__linux__)
+#if (defined(__linux__) || defined(__unix__))
 #include <pty.h>
 #else
 #include <util.h>


### PR DESCRIPTION
Changed: if defined(__linux__) to: if (defined(__linux__) || defined(__unix__))