### PR TITLE
Fix catkin_lint errors 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(serial)
+set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
 
 # Find catkin
 find_package(catkin REQUIRED)
@@ -11,20 +12,19 @@ endif()
 
 if(UNIX AND NOT APPLE)
     # If Linux, add rt and pthread
-    set(rt_LIBRARIES rt)
-    set(pthread_LIBRARIES pthread)
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include
-        DEPENDS rt pthread
-    )
+    find_package(pthread)
+    find_package(rt)
+    set(CATKIN_PACKAGE_DEPENDS "rt pthread")
+    #message("rt_LIBRARIES=${rt_LIBRARIES}")
+    #message("pthread_LIBRARIES=${pthread_LIBRARIES}")
 else()
-    # Otherwise normal call
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include
-    )
+    set(CATKIN_PACKAGE_DEPENDS "")
 endif()
+catkin_package(
+    LIBRARIES ${PROJECT_NAME}
+    INCLUDE_DIRS include
+    DEPENDS ${CATKIN_PACKAGE_DEPENDS}
+)
 
 ## Sources
 set(serial_SRCS
@@ -51,7 +51,7 @@ add_library(${PROJECT_NAME} ${serial_SRCS})
 if(APPLE)
     target_link_libraries(${PROJECT_NAME} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY})
 elseif(UNIX)
-    target_link_libraries(${PROJECT_NAME} rt pthread)
+  target_link_libraries(${PROJECT_NAME} ${rt_LIBRARIES} ${pthread_LIBRARIES})
 else()
     target_link_libraries(${PROJECT_NAME} setupapi)
 endif()

--- a/cmake/Findpthread.cmake
+++ b/cmake/Findpthread.cmake
@@ -1,0 +1,10 @@
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+if(Threads_FOUND)
+  #message( "lib pthread FOUND!" )
+  set(pthread_LIBRARIES Threads::Threads)
+  set(pthread_INCLUDE_DIRS ${Threads_INCLUDE_DIR})
+else(Threads_FOUND)
+  #message( "lib pthread NOT FOUND!" )
+endif()

--- a/cmake/Findrt.cmake
+++ b/cmake/Findrt.cmake
@@ -1,0 +1,16 @@
+include(FindPackageHandleStandardArgs)
+ 
+find_library(rt_LIBRARY rt)
+
+find_package_handle_standard_args(rt
+ DEFAULT_MSG
+  rt_LIBRARY
+)
+mark_as_advanced(rt_LIBRARY)
+
+if(rt_FOUND)
+  #message("lib rt FOUND!")
+  set(rt_LIBRARIES    ${rt_LIBRARY})
+else(rt_FOUND)
+  #message("lib rt NOT FOUND!")
+endif()


### PR DESCRIPTION
A suggestion to fix catkin_lint errors and be sure to set -pthread flag for compiler for UNIX systems (not only -lpthread flag for linker).
See [cmake and pthread discussions](https://www.it-swarm-fr.com/fr/pthreads/cmake-et-libpthread/968896822/) suggestions.