### PR TITLE
add dtr control to Serial constructor

### DIFF
--- a/include/serial/impl/unix.h
+++ b/include/serial/impl/unix.h
@@ -70,7 +70,8 @@ public:
               bytesize_t bytesize,
               parity_t parity,
               stopbits_t stopbits,
-              flowcontrol_t flowcontrol);
+              flowcontrol_t flowcontrol,
+              dtrcontrol_t dtrcontrol);
 
   virtual ~SerialImpl ();
 
@@ -117,7 +118,7 @@ public:
   setRTS (bool level);
 
   void
-  setDTR (bool level);
+  setDTR (dtrcontrol_t dtrcontrol);
 
   bool
   waitForChange ();
@@ -207,6 +208,7 @@ private:
   bytesize_t bytesize_;       // Size of the bytes
   stopbits_t stopbits_;       // Stop Bits
   flowcontrol_t flowcontrol_; // Flow Control
+  dtrcontrol_t dtrcontrol_;   // Data Terminal Ready Control
 
   // Mutex used to lock the read functions
   pthread_mutex_t read_mutex;

--- a/include/serial/impl/win.h
+++ b/include/serial/impl/win.h
@@ -59,7 +59,8 @@ public:
               bytesize_t bytesize,
               parity_t parity,
               stopbits_t stopbits,
-              flowcontrol_t flowcontrol);
+              flowcontrol_t flowcontrol,
+              dtrcontrol_t dtrcontrol);
 
   virtual ~SerialImpl ();
 
@@ -106,7 +107,7 @@ public:
   setRTS (bool level);
 
   void
-  setDTR (bool level);
+  setDTR (dtrcontrol_t dtrcontrol);
 
   bool
   waitForChange ();
@@ -193,6 +194,7 @@ private:
   bytesize_t bytesize_;       // Size of the bytes
   stopbits_t stopbits_;       // Stop Bits
   flowcontrol_t flowcontrol_; // Flow Control
+  dtrcontrol_t dtrcontrol_;   // Data Terminal Ready Control
 
   // Mutex used to lock the read functions
   HANDLE read_mutex;

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -89,6 +89,12 @@ typedef enum {
   flowcontrol_hardware
 } flowcontrol_t;
 
+typedef enum {
+    dtr_disable = 0,
+    dtr_enable = 1,
+    dtr_handshake = 2
+} dtrcontrol_t;
+
 /*!
  * Structure for setting the timeout of the serial port, times are
  * in milliseconds.
@@ -183,7 +189,8 @@ public:
           bytesize_t bytesize = eightbits,
           parity_t parity = parity_none,
           stopbits_t stopbits = stopbits_one,
-          flowcontrol_t flowcontrol = flowcontrol_none);
+          flowcontrol_t flowcontrol = flowcontrol_none,
+          dtrcontrol_t dtr = dtr_disable);
 
   /*! Destructor */
   virtual ~Serial ();
@@ -612,7 +619,7 @@ public:
 
   /*! Set the DTR handshaking line to the given level.  Defaults to true. */
   void
-  setDTR (bool level = true);
+  setDTR (dtrcontrol_t dtrcontrol = dtr_enable);
 
   /*!
    * Blocks until CTS, DSR, RI, CD changes or something interrupts it.

--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -34,10 +34,12 @@ _prefix_port_if_needed(const wstring &input)
 Serial::SerialImpl::SerialImpl (const string &port, unsigned long baudrate,
                                 bytesize_t bytesize,
                                 parity_t parity, stopbits_t stopbits,
-                                flowcontrol_t flowcontrol)
+                                flowcontrol_t flowcontrol,
+                                dtrcontrol_t dtrcontrol)
   : port_ (port.begin(), port.end()), fd_ (INVALID_HANDLE_VALUE), is_open_ (false),
     baudrate_ (baudrate), parity_ (parity),
-    bytesize_ (bytesize), stopbits_ (stopbits), flowcontrol_ (flowcontrol)
+    bytesize_ (bytesize), stopbits_ (stopbits),
+    flowcontrol_ (flowcontrol), dtrcontrol_ (dtrcontrol)
 {
   if (port_.empty () == false)
     open ();
@@ -254,6 +256,13 @@ Serial::SerialImpl::reconfigurePort ()
     dcbSerialParams.fRtsControl = RTS_CONTROL_HANDSHAKE;
     dcbSerialParams.fOutX = false;
     dcbSerialParams.fInX = false;
+  }
+
+  // setup dtr control
+  if (dtrcontrol_ == dtr_enable) {
+    dcbSerialParams.fDtrControl = DTR_CONTROL_ENABLE;
+  } else if (dtrcontrol_ == dtr_disable) {
+    dcbSerialParams.fDtrControl = DTR_CONTROL_DISABLE;
   }
 
   // activate settings
@@ -519,14 +528,14 @@ Serial::SerialImpl::setRTS (bool level)
 }
 
 void
-Serial::SerialImpl::setDTR (bool level)
+Serial::SerialImpl::setDTR (dtrcontrol_t dtrcontrol)
 {
   if (is_open_ == false) {
     throw PortNotOpenedException ("Serial::setDTR");
   }
-  if (level) {
+  if (dtrcontrol == dtr_enable) {
     EscapeCommFunction (fd_, SETDTR);
-  } else {
+  } else if (dtrcontrol == dtr_disable) {
     EscapeCommFunction (fd_, CLRDTR);
   }
 }

--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -533,6 +533,7 @@ Serial::SerialImpl::setDTR (dtrcontrol_t dtrcontrol)
   if (is_open_ == false) {
     throw PortNotOpenedException ("Serial::setDTR");
   }
+  dtrcontrol_ = dtrcontrol;
   if (dtrcontrol == dtr_enable) {
     EscapeCommFunction (fd_, SETDTR);
   } else if (dtrcontrol == dtr_disable) {

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -65,9 +65,9 @@ private:
 
 Serial::Serial (const string &port, uint32_t baudrate, serial::Timeout timeout,
                 bytesize_t bytesize, parity_t parity, stopbits_t stopbits,
-                flowcontrol_t flowcontrol)
+                flowcontrol_t flowcontrol, dtrcontrol_t dtrcontrol)
  : pimpl_(new SerialImpl (port, baudrate, bytesize, parity,
-                                           stopbits, flowcontrol))
+                                           stopbits, flowcontrol, dtrcontrol))
 {
   pimpl_->setTimeout(timeout);
 }
@@ -401,9 +401,9 @@ void Serial::setRTS (bool level)
   pimpl_->setRTS (level);
 }
 
-void Serial::setDTR (bool level)
+void Serial::setDTR (dtrcontrol_t dtrcontrol)
 {
-  pimpl_->setDTR (level);
+  pimpl_->setDTR (dtrcontrol);
 }
 
 bool Serial::waitForChange()


### PR DESCRIPTION
What:
Add Data-Terminal-Ready (DTR) control parameter to the Serial constructor.

Why:
To set the default in the constructor. The [arduino IDE](https://github.com/arduino/Arduino/blob/57a931c9c4c084057417837239ad8136f8a7b1aa/arduino-core/src/processing/app/Serial.java#L119) and [pyserial lib](https://github.com/pyserial/pyserial/blob/31fa4807d73ed4eb9891a88a15817b439c4eea2d/serial/serialutil.py#L190) both provide constructor arguments for setting the default DTR behaviour of a serial object without needing to make external calls to update the properties of a file handle after construction. This is desirable behaviour.

Solves #265 

How:
- Create a `dtrcontrol_t` enum with values `dtr_disable`, `dtr_enable`, and `dtr_handshake`.
  - `dtr_handshake` is non-functional.
- Add `dtrcontrol_t dtrcontrol_` field to `SerialImpl`.
- Replace `Serial::setDTR()` and `SerialImpl::setDTR()` bool parameters with `dtrcontrol_t` parameters.
- Set `SerialImpl::dtrcontrol_` to parameter value of `SerialImpl::setDTR()` in `SerialImpl::setDTR()`.
- Configure DTR within `SerialImpl::reconfigurePort()` depending on the value of `SerialImpl::dtrcontrol_`.
- Add `dtrcontrol_t` constructor arguments for both `Serial` and `SerialImpl` constructors.
  - The default `Serial` constructor parameter value of `dtrcontrol_t` is `dtr_disable`.

These changes are made to both windows and unix implementations.

If something is not satisfactory, please let me know and I will make adjustments. 
\- Maxine