### PR TITLE
Use macOS clock_gettime in timespec_now if it's available. Reduces CPU usage.

### DIFF
--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -82,14 +82,20 @@ timespec
 MillisecondTimer::timespec_now ()
 {
   timespec time;
-# ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
-  clock_serv_t cclock;
-  mach_timespec_t mts;
-  host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
-  clock_get_time(cclock, &mts);
-  mach_port_deallocate(mach_task_self(), cclock);
-  time.tv_sec = mts.tv_sec;
-  time.tv_nsec = mts.tv_nsec;
+// OS X does not have clock_gettime until 10.12, use clock_get_time
+#if defined(__MACH__) && MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+   if (__builtin_available(macOS 10.12, *)) {
+      clock_gettime(CLOCK_MONOTONIC, &time);
+   }
+   else {
+      clock_serv_t cclock;
+      mach_timespec_t mts;
+      host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+      clock_get_time(cclock, &mts);
+      mach_port_deallocate(mach_task_self(), cclock);
+      time.tv_sec = mts.tv_sec;
+      time.tv_nsec = mts.tv_nsec;
+   }
 # else
   clock_gettime(CLOCK_MONOTONIC, &time);
 # endif


### PR DESCRIPTION
We were finding high CPU usage on macOS when connected to very active serial connections. After running the XCode profiler it pointed to this function.

clock_gettime is available in macOS 10.12 and higher. This change is to use that if it's available. If they are targeting a lower macOS minimum version check it at runtime, otherwise do it at compile time.

CPU usage was reduced to a more acceptable level.