### PR TITLE
Implement waitReadable and waitByteTime on Windows

### DIFF
--- a/include/serial/impl/win.h
+++ b/include/serial/impl/win.h
@@ -198,6 +198,7 @@ private:
   HANDLE read_mutex;
   // Mutex used to lock the write functions
   HANDLE write_mutex;
+  OVERLAPPED overlapped_;
 };
 
 }

--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -427,7 +427,17 @@ Serial::SerialImpl::setTimeout (serial::Timeout &timeout)
 {
   timeout_ = timeout;
   if (is_open_) {
-    reconfigurePort ();
+    //reconfigurePort ();
+    // Setup timeouts
+    COMMTIMEOUTS timeouts = { 0 };
+    timeouts.ReadIntervalTimeout = timeout_.inter_byte_timeout;
+    timeouts.ReadTotalTimeoutConstant = timeout_.read_timeout_constant;
+    timeouts.ReadTotalTimeoutMultiplier = timeout_.read_timeout_multiplier;
+    timeouts.WriteTotalTimeoutConstant = timeout_.write_timeout_constant;
+    timeouts.WriteTotalTimeoutMultiplier = timeout_.write_timeout_multiplier;
+    if (!SetCommTimeouts(fd_, &timeouts)) {
+        THROW(IOException, "Error setting timeouts.");
+    }
   }
 }
 

--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -322,9 +322,13 @@ Serial::SerialImpl::waitReadable (uint32_t /*timeout*/)
 }
 
 void
-Serial::SerialImpl::waitByteTimes (size_t /*count*/)
+Serial::SerialImpl::waitByteTimes (size_t count)
 {
-  THROW (IOException, "waitByteTimes is not implemented on Windows.");
+  DWORD wait_time = timeout_.inter_byte_timeout * count;
+  HANDLE wait_event = CreateEvent(NULL, FALSE, FALSE, NULL);
+  ResetEvent(wait_event);
+  WaitForSingleObject(wait_event, wait_time);
+  CloseHandle(wait_event);
 }
 
 size_t


### PR DESCRIPTION
In order to implement timeout function of waitReadable,  MS Asynchronized I/O feature is introduced with FILE_FALG_OVERLAPPED flag of CreateFileW method.

Both read and write method have been refactored to support asynchronized I/O.

I have briefly tested it with test_serial subproject. It seems work fine. Looking forward to more testing.