### PR TITLE
Full duplex support on Windows.

### DIFF
--- a/include/serial/impl/win.h
+++ b/include/serial/impl/win.h
@@ -195,12 +195,12 @@ private:
   flowcontrol_t flowcontrol_; // Flow Control
 
   // Mutex used to lock the read functions
-  HANDLE read_mutex;
+  HANDLE read_mutex_;
   // Mutex used to lock the write functions
-  HANDLE write_mutex;
+  HANDLE write_mutex_;
 
-  OVERLAPPED ov_read;           // OVERLAPPED read
-  OVERLAPPED ov_write;          // OVERLAPPED write
+  OVERLAPPED ov_read_;           // OVERLAPPED read
+  OVERLAPPED ov_write_;          // OVERLAPPED write
 };
 
 }

--- a/include/serial/impl/win.h
+++ b/include/serial/impl/win.h
@@ -198,6 +198,9 @@ private:
   HANDLE read_mutex;
   // Mutex used to lock the write functions
   HANDLE write_mutex;
+
+  OVERLAPPED ov_read;           // OVERLAPPED read
+  OVERLAPPED ov_write;          // OVERLAPPED write
 };
 
 }


### PR DESCRIPTION
## Add full duplex communications support on Windows.

When I use a separate thread to read the serial data, I notice that the write operation is blocked.

Here is a simple program to illustrate this.

```c++
#include <iostream>
#include <chrono>
#include <thread>
#include "serial/serial.h"

using namespace std;
using namespace chrono;
using namespace std::chrono_literals;
using namespace serial;

int main(int argc, char **argv) {
    Serial serial_port("COM5", 9600, Timeout::simpleTimeout(200));

    thread read_serial([&](){
        while (true) {
            uint8_t ch;
            serial_port.read(&ch, 1);
        }
    });

    while (true) {
        // Test write latency.
        auto start = high_resolution_clock::now();
        serial_port.write("Hello world!\n");
        auto end = high_resolution_clock::now();
        double dt = duration<double>(end - start).count();

        cout << "Write using " << (dt * 1000) << " ms" << endl;

        this_thread::sleep_for(500ms);
    }
}
```

Output:

```
Write using 0.0576 ms
Write using 314.211 ms
Write using 325.428 ms
Write using 299.138 ms
Write using 524.347 ms
Write using 702.12 ms
Write using 513.909 ms
...
```

This does not make sense because the serial port is supposed to communicate asynchronously. To fix this problem, I modified `win.h` and `win.cc` to enable asynchronous communication by adding the OVERLAPPED option. This also helps to solve the issue #150.

This is the right result:

```
Write using 0.0093 ms
Write using 0.034 ms
Write using 0.0564 ms
Write using 0.012 ms
Write using 0.0343 ms
Write using 0.0494 ms
Write using 0.0124 ms
Write using 0.01 ms
```

