### PR TITLE
Add support to enumerate serial ports on certain arm SOCs

### DIFF
--- a/src/impl/list_ports/list_ports_linux.cc
+++ b/src/impl/list_ports/list_ports_linux.cc
@@ -306,6 +306,7 @@ serial::list_ports()
     search_globs.push_back("/dev/tty.*");
     search_globs.push_back("/dev/cu.*");
     search_globs.push_back("/dev/rfcomm*");
+    search_globs.push_back("/dev/ttyTHS*");
 
     vector<string> devices_found = glob( search_globs );
 


### PR DESCRIPTION
Some ARM devices enumerate uart ports as /dev/ttyTHS0, 1, 2, 3 and 4. 
Added search blob to scan these devices.