### PR TITLE
Use `PurgeComm` for flush

### DIFF
--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -465,7 +465,8 @@ Serial::SerialImpl::flush ()
   if (is_open_ == false) {
     throw PortNotOpenedException ("Serial::flush");
   }
-  FlushFileBuffers (fd_);
+  PurgeComm(fd_, PURGE_RXCLEAR);
+  PurgeComm(fd_, PURGE_TXCLEAR);	
 }
 
 void


### PR DESCRIPTION
NOTE about `FlushFileBuffers`:

> If hFile is a handle to a communications device, the function only flushes the transmit buffer.  

Source: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers