### PR TITLE
Fixing compiler warning in win.cc

### DIFF
--- a/src/impl/win.cc
+++ b/src/impl/win.cc
@@ -3,6 +3,7 @@
 /* Copyright 2012 William Woodall and John Harrison */
 
 #include <sstream>
+#include <algorithm>
 
 #include "serial/impl/win.h"
 
@@ -366,7 +367,11 @@ Serial::SerialImpl::setPort (const string &port)
 string
 Serial::SerialImpl::getPort () const
 {
-  return string(port_.begin(), port_.end());
+    string str(port_.length(), 0);
+    std::transform(port_.begin(), port_.end(), str.begin(), [] (wchar_t c) {
+        return (char)c;
+    });
+    return str;
 }
 
 void


### PR DESCRIPTION
The converstion from a wstring to std::string gave a warning:
C4244: 'argument': conversion from 'const wchar_t' to 'const _Elem', possible loss of data.

Conversion used to be recommended with codecvt, but that has been deprecated, so a transform here is simplest I think.

For reference on the options:
https://stackoverflow.com/questions/4804298/how-to-convert-wstring-into-string/12097772#12097772