### PR TITLE
changed cmake to support ros2 ws, catkin to  ament

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,13 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.8)
 project(serial)
 
-# Find catkin
-find_package(catkin REQUIRED)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+
+
+# Find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gtest REQUIRED)
+
 
 if(APPLE)
     find_library(IOKIT_LIBRARY IOKit)
@@ -13,17 +18,6 @@ if(UNIX AND NOT APPLE)
     # If Linux, add rt and pthread
     set(rt_LIBRARIES rt)
     set(pthread_LIBRARIES pthread)
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include
-        DEPENDS rt pthread
-    )
-else()
-    # Otherwise normal call
-    catkin_package(
-        LIBRARIES ${PROJECT_NAME}
-        INCLUDE_DIRS include
-    )
 endif()
 
 ## Sources
@@ -48,6 +42,8 @@ endif()
 
 ## Add serial library
 add_library(${PROJECT_NAME} ${serial_SRCS})
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 if(APPLE)
     target_link_libraries(${PROJECT_NAME} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY})
 elseif(UNIX)
@@ -56,26 +52,37 @@ else()
     target_link_libraries(${PROJECT_NAME} setupapi)
 endif()
 
-## Uncomment for example
-add_executable(serial_example examples/serial_example.cc)
-add_dependencies(serial_example ${PROJECT_NAME})
-target_link_libraries(serial_example ${PROJECT_NAME})
-
 ## Include headers
 include_directories(include)
 
-## Install executable
+## Install library
 install(TARGETS ${PROJECT_NAME}
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
 )
 
 ## Install headers
-install(FILES include/serial/serial.h include/serial/v8stdint.h
-  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/serial)
+install(DIRECTORY include/serial
+  DESTINATION include
+)
+
+## Example executable
+add_executable(serial_example examples/serial_example.cc)
+ament_target_dependencies(serial_example)
+
+target_link_libraries(serial_example ${PROJECT_NAME})
+
+install(TARGETS serial_example
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
 
 ## Tests
-if(CATKIN_ENABLE_TESTING)
+if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
+
+# Package
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+ament_package()

--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ Install:
 
 ### License
 
-[The MIT License](LICENSE)
+The MIT License
+
+Copyright (c) 2012 William Woodall, John Harrison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### Authors
 

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>serial</name>
   <version>1.2.1</version>
   <description>
@@ -9,7 +9,6 @@
   </description>
 
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
-
   <license>MIT</license>
 
   <url type="website">http://wjwwood.github.com/serial/</url>
@@ -19,6 +18,18 @@
   <author email="wjwwood@gmail.com">William Woodall</author>
   <author email="ash.gti@gmail.com">John Harrison</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <!-- Dependencies for ROS 2 Humble -->
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>rcutils</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,12 +1,13 @@
 if(UNIX)
-    catkin_add_gtest(${PROJECT_NAME}-test unix_serial_tests.cc)
+    ament_add_gtest(${PROJECT_NAME}-test unix_serial_tests.cc)
     target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+    
     if(NOT APPLE)
         target_link_libraries(${PROJECT_NAME}-test util)
     endif()
 
     if(NOT APPLE)  # these tests are unreliable on macOS
-      catkin_add_gtest(${PROJECT_NAME}-test-timer unit/unix_timer_tests.cc)
-      target_link_libraries(${PROJECT_NAME}-test-timer ${PROJECT_NAME})
+        ament_add_gtest(${PROJECT_NAME}-test-timer unit/unix_timer_tests.cc)
+        target_link_libraries(${PROJECT_NAME}-test-timer ${PROJECT_NAME})
     endif()
 endif()


### PR DESCRIPTION
I was unable to build my ros2 humble workspace needed for the robotiq 3F gripper. So I changed the cmakelist with respect to the ros2 requirement.