### PR TITLE
Fix compatibility with CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.3...3.5)
 project(serial)
 
 # Find catkin


### PR DESCRIPTION
Without this change, configuration in CMake 4.0 fails with:

~~~
CMake Error at build/_deps/serial-src/CMakeLists.txt:1 (cmake_minimum_required):
-- Configuring incomplete, errors occurred!
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
~~~